### PR TITLE
Update DownloadLatestDriver() to current process

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -17,6 +17,4 @@ jobs:
 
       - name: Build with dotnet
         run: dotnet build --configuration Release
-        
-      - name: Test with dotnet
-        run: dotnet test
+

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -18,3 +18,5 @@ jobs:
       - name: Build with dotnet
         run: dotnet build --configuration Release
         
+      - name: Test with dotnet
+        run: dotnet test

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -17,6 +17,3 @@ jobs:
 
       - name: Build with dotnet
         run: dotnet build --configuration Release
-        
-      - name: Test with dotnet
-        run: dotnet test

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -3,7 +3,7 @@ name: Validate PR
 on:
   pull_request_target:
     branches:
-      - main
+      - master
 jobs:
   build-api:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -17,3 +17,6 @@ jobs:
 
       - name: Build with dotnet
         run: dotnet build --configuration Release
+        
+      - name: Test with dotnet
+        run: dotnet test

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,20 @@
+name: Validate PR
+
+on:
+  pull_request_target:
+    branches:
+      - main
+jobs:
+  build-api:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up .NET Core
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Build with dotnet
+        run: dotnet build --configuration Release
+        

--- a/Sl.Selenium.Chrome/ChromeDriverDownloader/ChromeDriverDownloader.cs
+++ b/Sl.Selenium.Chrome/ChromeDriverDownloader/ChromeDriverDownloader.cs
@@ -6,7 +6,6 @@ using System.Net;
 using System.Runtime.InteropServices;
 using System;
 using System.Linq;
-using System.Runtime.CompilerServices;
 
 namespace Sl.Selenium.Extensions.Chrome.DriverDownloader
 {

--- a/Sl.Selenium.Chrome/ChromeDriverDownloader/ChromeDriverDownloader.cs
+++ b/Sl.Selenium.Chrome/ChromeDriverDownloader/ChromeDriverDownloader.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Runtime.InteropServices;
 using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Sl.Selenium.Extensions.Chrome.DriverDownloader
 {

--- a/Sl.Selenium.Chrome/ChromeDriverDownloader/ChromeDriverDownloader.cs
+++ b/Sl.Selenium.Chrome/ChromeDriverDownloader/ChromeDriverDownloader.cs
@@ -1,0 +1,108 @@
+﻿using Newtonsoft.Json;
+using Selenium.Extensions;
+using System.IO.Compression;
+using System.IO;
+using System.Net;
+using System.Runtime.InteropServices;
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace Sl.Selenium.Extensions.Chrome.DriverDownloader
+{
+	public class ChromeDriverDownloader
+	{
+		private readonly ChromeDriverDownloaderOptions options;
+
+		public ChromeDriverDownloader(ChromeDriverDownloaderOptions options)
+		{
+			this.options = options;
+		}
+
+		public void DownloadLatestDriver()
+		{
+			Console.WriteLine("Downloading chrome driver");
+
+			using (WebClient client = new WebClient())
+			{
+				var version = GetLatestStableVersionNumber(client);
+				var installer = GetInstallerPathForVersion(version, client);
+				DownloadInstaller(installer, client);
+			}
+		}
+
+		protected string GetLatestStableVersionNumber(WebClient client)
+		{
+			const string url = "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json";
+
+			string jsonData = client.DownloadString(url);
+
+			var chromeVersions = JsonConvert.DeserializeObject<LastKnownGoodVersions>(jsonData);
+
+			var version = chromeVersions.channels.Stable.version;
+
+			return version;
+		}
+
+		protected string GetInstallerPathForVersion(string version, WebClient client)
+		{
+			const string url = "https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json";
+
+			string jsonData = client.DownloadString(url);
+
+			var response = JsonConvert.DeserializeObject<KnownGoodVersionsWithDownloads>(jsonData);
+
+			var versionInfo = response.Versions.FirstOrDefault(v => v.version == version);
+			if (versionInfo == null)
+			{
+				throw new Exception($"Version {version} not found on endpoint {url}");
+			}
+
+			string requiredPlatform = "";
+			switch (Platform.CurrentOS)
+			{
+				case OperatingSystemType.Windows:
+					requiredPlatform = RuntimeInformation.OSArchitecture == Architecture.X64 ? "win64" : "win32";
+					break;
+				case OperatingSystemType.OSX:
+					requiredPlatform = RuntimeInformation.OSArchitecture == Architecture.X64 ? "mac-x64" : "mac-arm64";
+					break;
+				case OperatingSystemType.Linux:
+					requiredPlatform = "linux64";
+					break;
+				default:
+					throw new Exception("Unknown OS: " + Platform.CurrentOS);
+			}
+
+			var platformInfo = versionInfo.downloads["chromedriver"].FirstOrDefault(p => p.platform == requiredPlatform);
+
+			if (platformInfo == null)
+			{
+				throw new Exception($"Could not find installer for version: {version} and platform: {requiredPlatform}");
+			}
+
+			return platformInfo.url;
+		}
+
+		protected void DownloadInstaller(string installer, WebClient client)
+		{
+			Directory.CreateDirectory(options.DriversFolderPath);
+			string compressedFilePath = options.DriverPath + ".zip";
+
+			client.DownloadFile(installer, compressedFilePath);
+
+			var filesBefore = Directory.GetFiles(options.DriversFolderPath);
+
+			ZipFile.ExtractToDirectory(compressedFilePath, options.DriversFolderPath);
+
+			var directoryAfter = Directory.GetDirectories(options.DriversFolderPath).First();
+			var filesAfter = Directory.GetFiles(directoryAfter);
+
+			var extractedChromeDriver = filesAfter.First(f => !filesBefore.Contains(f));
+
+			File.Move(extractedChromeDriver, options.DriverPath);
+			File.Delete(compressedFilePath);
+			Directory.Delete(directoryAfter, true);
+		}
+	}
+}

--- a/Sl.Selenium.Chrome/ChromeDriverDownloader/ChromeDriverDownloaderOptions.cs
+++ b/Sl.Selenium.Chrome/ChromeDriverDownloader/ChromeDriverDownloaderOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Sl.Selenium.Extensions.Chrome.DriverDownloader
+{
+	public class ChromeDriverDownloaderOptions
+	{
+		public string DriversFolderPath { get; set; }
+		public string DriverPath { get; set; }
+	}
+}

--- a/Sl.Selenium.Chrome/ChromeDriverDownloader/KnownGoodVersionsWithDownloads.cs
+++ b/Sl.Selenium.Chrome/ChromeDriverDownloader/KnownGoodVersionsWithDownloads.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+
+namespace Sl.Selenium.Extensions.Chrome.DriverDownloader
+{
+	public class Download
+	{
+		public string platform { get; set; }
+		public string url { get; set; }
+	}
+
+	public class VersionInfo
+	{
+		public string version { get; set; }
+		public string Revision { get; set; }
+		public Dictionary<string, List<Download>> downloads { get; set; }
+	}
+
+	public class KnownGoodVersionsWithDownloads
+	{
+		public string Timestamp { get; set; }
+		public List<VersionInfo> Versions { get; set; }
+	}
+}

--- a/Sl.Selenium.Chrome/ChromeDriverDownloader/LastKnownGoodVersions.cs
+++ b/Sl.Selenium.Chrome/ChromeDriverDownloader/LastKnownGoodVersions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Sl.Selenium.Extensions.Chrome.DriverDownloader
+{
+	public class ChannelInfo
+	{
+		public string channel { get; set; }
+		public string version { get; set; }
+		public string revision { get; set; }
+	}
+
+	public class Channels
+	{
+		public ChannelInfo Stable { get; set; }
+		public ChannelInfo Beta { get; set; }
+		public ChannelInfo Dev { get; set; }
+		public ChannelInfo Canary { get; set; }
+	}
+
+	public class LastKnownGoodVersions
+	{
+		public DateTime timestamp { get; set; }
+		public Channels channels { get; set; }
+	}
+}

--- a/Sl.Selenium.Chrome/Sl.Selenium.Extensions.Chrome.csproj
+++ b/Sl.Selenium.Chrome/Sl.Selenium.Extensions.Chrome.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <Authors>emre-gon</Authors>
     <Copyright>2022</Copyright>
     <PackageProjectUrl>https://github.com/emre-gon/Sl.Selenium.Extensions.Drivers</PackageProjectUrl>

--- a/Sl.Selenium.Chrome/SlChromeDriver.cs
+++ b/Sl.Selenium.Chrome/SlChromeDriver.cs
@@ -4,6 +4,7 @@ using OpenQA.Selenium.DevTools;
 using OpenQA.Selenium.Remote;
 using Selenium.Extensions;
 using Sl.Selenium.Extensions.Chrome;
+using Sl.Selenium.Extensions.Chrome.DriverDownloader;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -391,56 +392,16 @@ namespace Sl.Selenium.Extensions
 
         protected override void DownloadLatestDriver()
         {
-            Console.WriteLine("Downloading chrome driver");
-            string chromeRepo = "https://chromedriver.storage.googleapis.com";
+			Console.WriteLine("Downloading chrome driver");
 
-            using (WebClient client = new WebClient())
-            {
-                string latestVersion = client.DownloadString(chromeRepo + "/LATEST_RELEASE");
+			var downloader = new ChromeDriverDownloader(new ChromeDriverDownloaderOptions
+			{
+				DriversFolderPath = DriversFolderPath(),
+				DriverPath = DriverPath()
+			});
 
-
-                string downloadPath;
-                switch (Platform.CurrentOS)
-                {
-                    case OperatingSystemType.Windows:
-                        downloadPath = "chromedriver_win32.zip";
-                        break;
-                    case OperatingSystemType.OSX:
-                        downloadPath = "chromedriver_mac64.zip";
-                        break;
-                    case OperatingSystemType.Linux:
-                        downloadPath = "chromedriver_linux64.zip";
-                        break;
-                    default:
-                        throw new Exception("Unknown OS");
-                }
-
-                Directory.CreateDirectory(DriversFolderPath());
-                string compressedFilePath = DriverPath() + ".zip";
-
-
-                client.DownloadFile($"{chromeRepo}/{latestVersion}/{downloadPath}", compressedFilePath);
-
-
-
-                var filesBefore = Directory.GetFiles(DriversFolderPath());
-
-                ZipFile.ExtractToDirectory(compressedFilePath, DriversFolderPath());
-
-
-                var filesAfter = Directory.GetFiles(DriversFolderPath());
-
-
-                var extractedChromeDriver = filesAfter.First(f => !filesBefore.Contains(f));
-
-
-                File.Delete(compressedFilePath);
-                File.Move(extractedChromeDriver, DriverPath());
-            }
-
-
-
-        }
+			downloader.DownloadLatestDriver();
+		}
 
         public DevToolsSession GetDevToolsSession()
         {


### PR DESCRIPTION
Starting on version 115, Chrome Driver changed the way they provide new versions. This PR implements those changes on the DownloadLatestDriver() method:

More details on the new procedure to get the latest version here: https://chromedriver.chromium.org/downloads/version-selection
